### PR TITLE
Refactor GitHub Actions workflow to delete merged branch

### DIFF
--- a/.github/workflows/DocumentMergedCommits.yaml
+++ b/.github/workflows/DocumentMergedCommits.yaml
@@ -85,10 +85,6 @@ jobs:
             exit 1
           fi
 
-      - name: Checkout repository
-        if: ${{ env.SKIP_ALL == 'false' }}
-        uses: actions/checkout@v4
-
       - name: Get newly added commits
         id: list-commits
         if: ${{ env.SKIP_ALL == 'false' }}
@@ -144,3 +140,13 @@ jobs:
             gh pr comment ${{ env.FEATURE_PR_NUMBER }} --body '${{ env.COMMIT_COMMENT_TAG }}
             $body'
           fi
+
+  delete-head:
+    name: Delete head branch
+    needs: list-commits
+    runs-on: ubuntu-latest
+    steps:
+      - name: delete branch
+        uses: SvanBoxel/delete-merged-branch@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request refactors the GitHub Actions workflow to include a step that deletes the merged branch after the pull request is closed. This has to be done after the documentation job to make sure the picked commits can still be retrieved.