### PR TITLE
Refactor DocumentMergedCommits workflow to clean up automated comments after merge

### DIFF
--- a/.github/workflows/DocumentMergedCommits.yaml
+++ b/.github/workflows/DocumentMergedCommits.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Set environment variables
         if: ${{ env.SKIP_ALL == 'false' }}
         run: |
-          echo "TEST_BRANCH=${{ vars.UPDATETESTBRANCH_TEST_BRANCH || env.TEST_BRANCH }}" >> $GITHUB_ENV
+          echo "NOTICE_COMMENT_TAG=${{ vars.UPDATETESTBRANCH_NOTICE_COMMENT_TAG || env.NOTICE_COMMENT_TAG }}" >> $GITHUB_ENV
           echo "COMMIT_COMMENT_TAG=${{ vars.UPDATETESTBRANCH_COMMIT_COMMENT_TAG || env.COMMIT_COMMENT_TAG }}" >> $GITHUB_ENV
           echo "BOT_LABEL=${{ vars.UPDATETESTBRANCH_BOT_LABEL || env.BOT_LABEL }}" >> $GITHUB_ENV
           echo "FEATURE_TEST_PREFIX=${{ vars.UPDATETESTBRANCH_FEATURE_TEST_PREFIX || env.FEATURE_TEST_PREFIX }}" >> $GITHUB_ENV
@@ -90,8 +90,7 @@ jobs:
         if: ${{ env.SKIP_ALL == 'false' }}
         run: |
           git fetch origin
-          common_branch=$(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
-          added_commits=$(git log --no-merges --pretty=format:%h $common_branch..${{ github.event.pull_request.head.sha }})
+          added_commits=$(git log --no-merges --pretty=format:%h ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
 
           echo "Non-merge commits added:"
           for commit in $added_commits; do
@@ -131,6 +130,29 @@ jobs:
             echo "$picked_commits"
             echo "EOF"
           } >> $GITHUB_ENV
+
+          - name: Clean up comments
+            if: ${{ env.SKIP_ALL == 'false' }}
+            uses: actions/github-script@v7
+            with:
+              script: |
+                const oldPrComments = github.rest.issues.listComments({
+                  issue_number: ${{ env.FEATURE_PR_NUMBER }},
+                  owner: context.repo.owner,
+                  repo: context.repo.repo
+                })
+                oldPrComments.forEach(comments => {
+                  comments.data.forEach(comment => {
+                    if (comment.user.login === 'github-actions[bot]' && comment.body.startsWith('${{ env.NOTICE_COMMENT_TAG }}')) {
+                      github.rest.issues.deleteComment({
+                        comment_id: comment.id,
+                        owner: context.repo.owner,
+                        repo: context.repo.repo
+                      })
+                      process.stdout.write(`Deleted comment ${comment.html_url}\n`)
+                    }
+                  })
+                })
 
       - name: Comment on the original pull request
         if: ${{ env.SKIP_ALL == 'false' }}


### PR DESCRIPTION
This pull request refactors the DocumentMergedCommits workflow to clean up automated comments after the merge process. It removes unnecessary comments left by the workflow and ensures a cleaner pull request history.