### PR TITLE
Add name to list-commits job in DocumentMergedCommits.yaml

### DIFF
--- a/.github/workflows/DocumentMergedCommits.yaml
+++ b/.github/workflows/DocumentMergedCommits.yaml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   list-commits:
+    name: List commits in feature PR
     if: ${{ github.event.pull_request.merged == true }} && contains(github.event.pull_request.labels.*.name, env.BOT_LABEL)
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This pull request adds a name to the list-commits job in the DocumentMergedCommits.yaml file.