### PR TITLE
Remove condition for delete-head job in DocumentMergedCommits.yaml

### DIFF
--- a/.github/workflows/DocumentMergedCommits.yaml
+++ b/.github/workflows/DocumentMergedCommits.yaml
@@ -170,7 +170,6 @@ jobs:
 
   delete-head:
     name: Delete head branch
-    if: ${{ github.event.pull_request.merged == true }}
     needs: list-commits
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/DocumentMergedCommits.yaml
+++ b/.github/workflows/DocumentMergedCommits.yaml
@@ -171,6 +171,7 @@ jobs:
   delete-head:
     name: Delete head branch
     needs: list-commits
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
       - name: Set up Git


### PR DESCRIPTION
This pull request removes the condition for the delete-head job in the DocumentMergedCommits.yaml file. The condition was previously checking if the pull request was merged, but it is no longer necessary.