### PR TITLE
Fix condition in DocumentMergedCommits.yaml workflow

### DIFF
--- a/.github/workflows/DocumentMergedCommits.yaml
+++ b/.github/workflows/DocumentMergedCommits.yaml
@@ -172,7 +172,7 @@ jobs:
           fi
 
       - name: Comment on the original pull request
-        if: ${{ env.SKIP_ALL == 'false' }} && steps.set-comment-body.outputs.COMMENT_BODY
+        if: ${{ env.SKIP_ALL == 'false' }} && ${{ steps.set-comment-body.outputs.COMMENT_BODY }}
         run: |
           echo "${{ steps.set-comment-body.outputs.COMMENT_BODY }}"
           gh pr comment ${{ env.FEATURE_PR_NUMBER }} --body "${{ env.COMMIT_COMMENT_TAG }}


### PR DESCRIPTION
This pull request fixes a condition in the DocumentMergedCommits.yaml workflow. The condition was not properly checking the value of the `steps.set-comment-body.outputs.COMMENT_BODY` variable. This caused the `Comment on the original pull request` step to not run when it should have. This PR ensures that the step runs correctly by fixing the condition.