### PR TITLE
Print git info to debug

### DIFF
--- a/.github/workflows/UpdateTestBranch.yaml
+++ b/.github/workflows/UpdateTestBranch.yaml
@@ -138,8 +138,37 @@ jobs:
         id: get_cherry_picked_commits
         if: ${{ env.SKIP_ALL == 'false' && steps.check_feat_test.outputs.SKIP_CHERRY_LIST == 'false' }}
         run: |
+          main_history=$(git log --decorate --oneline origin/main)
+          feature_history=$(git log --decorate --oneline origin/feature)
+          echo "Before fetch:\nFeature history:\n"
+          echo "$feature_history" | while read -r line; do
+            commit=$(echo "$line" | awk '{print $1}')
+            if ! grep -q "$commit" <<< "$main_history"; then
+              echo "::warning::$line (not present in main history)"
+            else
+              echo "$line"
+              # Remove the line from main_history
+              main_history=$(grep -v "$commit" <<< "$main_history")
+            fi
+          done
+
           git fetch origin ${{ env.TEST_BRANCH }}
           git fetch origin ${{ env.FEATURE_TEST_BRANCH }}
+
+          main_history=$(git log --decorate --oneline origin/main)
+          feature_history=$(git log --decorate --oneline origin/feature)
+          echo "Before fetch:\nFeature history:\n"
+          echo "$feature_history" | while read -r line; do
+            commit=$(echo "$line" | awk '{print $1}')
+            if ! grep -q "$commit" <<< "$main_history"; then
+              echo "::warning::$line (not present in main history)"
+            else
+              echo "$line"
+              # Remove the line from main_history
+              main_history=$(grep -v "$commit" <<< "$main_history")
+            fi
+          done
+
           feature_test_bodies=$(git log --reverse --pretty=format:%b origin/${{ env.TEST_BRANCH }}..origin/${{ env.FEATURE_TEST_BRANCH }})
 
           if [ -z "$feature_test_bodies" ]; then


### PR DESCRIPTION
This pull request adds a new feature to print git information for debugging purposes. It includes changes to the code that fetches and compares the commit history between the main branch and the feature branch. This will help in identifying any missing commits and potential issues.