### PR TITLE
Update comment condition in DocumentMergedCommits.yaml workflow

### DIFF
--- a/.github/workflows/DocumentMergedCommits.yaml
+++ b/.github/workflows/DocumentMergedCommits.yaml
@@ -172,7 +172,7 @@ jobs:
           fi
 
       - name: Comment on the original pull request
-        if: ${{ env.SKIP_ALL == 'false' }} && ${{ steps.set-comment-body.outputs.COMMENT_BODY }}
+        if: ${{ env.SKIP_ALL == 'false' }} && ${{ steps.set-comment-body.outputs.COMMENT_BODY != '' }}
         run: |
           echo "${{ steps.set-comment-body.outputs.COMMENT_BODY }}"
           gh pr comment ${{ env.FEATURE_PR_NUMBER }} --body "${{ env.COMMIT_COMMENT_TAG }}


### PR DESCRIPTION
This pull request updates the comment condition in the DocumentMergedCommits.yaml workflow. The if statement now checks if the COMMENT_BODY is not empty before running the command to comment on the original pull request. This ensures that a comment is only made if there is a body to be added.