### PR TITLE
Update fetch command in UpdateTestBranch.yaml workflow to use origin/ branch references

### DIFF
--- a/.github/workflows/UpdateTestBranch.yaml
+++ b/.github/workflows/UpdateTestBranch.yaml
@@ -102,8 +102,8 @@ jobs:
           git fetch origin ${{ steps.pull_request.outputs.BASE_REF }}
           git fetch origin ${{ steps.pull_request.outputs.HEAD_REF }}
 
-          main_history=$(git log --decorate --oneline ${{ steps.pull_request.outputs.BASE_REF }})
-          feature_history=$(git log --decorate --oneline ${{ steps.pull_request.outputs.HEAD_REF }})
+          main_history=$(git log --decorate --oneline origin/${{ steps.pull_request.outputs.BASE_REF }})
+          feature_history=$(git log --decorate --oneline origin/${{ steps.pull_request.outputs.HEAD_REF }})
           echo "$feature_history" | while read -r line; do
             commit=$(echo "$line" | awk '{print $1}')
             if ! grep -q "$commit" <<< "$main_history"; then


### PR DESCRIPTION
This pull request updates the fetch command in the UpdateTestBranch.yaml workflow to use origin/ branch references instead of the pull request outputs. This ensures that the correct branches are fetched and avoids any potential issues with the pull request outputs.