### PR TITLE
Fix missing closing quote in UpdateTestBranch.yaml workflow

### DIFF
--- a/.github/workflows/UpdateTestBranch.yaml
+++ b/.github/workflows/UpdateTestBranch.yaml
@@ -279,7 +279,7 @@ jobs:
         run: |
           feature_commits=(${{ env.FEATURE_COMMITS }})
           echo "Cherry-picking the following commits:"
-          echo "${feature_commits[*]}
+          echo "${feature_commits[*]}"
           successful_commits=()
 
           for commit in "${feature_commits[@]}"; do


### PR DESCRIPTION
This pull request fixes a missing closing quote in the UpdateTestBranch.yaml workflow file.