### PR TITLE
Update commit iteration to use arrays instead of strings in workflows

### DIFF
--- a/.github/workflows/DocumentMergedCommits.yaml
+++ b/.github/workflows/DocumentMergedCommits.yaml
@@ -94,7 +94,7 @@ jobs:
           added_commits=$(git log --no-merges --pretty=format:%h ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }})
 
           echo "Non-merge commits added:"
-          for commit in "$added_commits"; do
+          for commit in $added_commits; do
             echo "- $commit"
           done
 

--- a/.github/workflows/UpdateTestBranch.yaml
+++ b/.github/workflows/UpdateTestBranch.yaml
@@ -115,7 +115,7 @@ jobs:
           feature_commits_pretty=$(git log --reverse --no-merges --pretty=format:"- %s (%H)" origin/${{ steps.pull_request.outputs.BASE_REF }}..origin/${{ steps.pull_request.outputs.HEAD_REF }})
 
           echo -e 'Feature commits:\n'"$feature_commits_pretty"
-          for commit in "$feature_commits"; do
+          for commit in $feature_commits; do
             echo "::debug::$commit"
           done
 
@@ -152,7 +152,7 @@ jobs:
           fi
 
           picked_commits=()
-          for msg in "$feature_test_bodies"; do
+          for msg in $feature_test_bodies; do
             echo "::debug::Full message: $msg"
             last_line=$(echo "$msg" | tail -n 1)
             echo "::debug::Last line: $last_line"
@@ -205,7 +205,7 @@ jobs:
               echo 'Found comment with the tag "${{ env.COMMIT_COMMENT_TAG }}".'
               found_commits=$(echo "$body" | grep -oP '(?<=^- )\S*')
               echo "Added commits:"
-              for commit in "$found_commits"; do
+              for commit in $found_commits; do
                 echo "- $commit"
               done
               added_commits+=($found_commits)


### PR DESCRIPTION
This pull request updates the commit iteration in the workflows to use arrays instead of strings. This change improves the efficiency and readability of the code.