### PR TITLE
Fix conditional statement in DocumentMergedCommits.yaml workflow

### DIFF
--- a/.github/workflows/DocumentMergedCommits.yaml
+++ b/.github/workflows/DocumentMergedCommits.yaml
@@ -186,7 +186,7 @@ jobs:
       - name: Comment on the original pull request
         if: ${{ env.SKIP_ALL == 'false' }}
         run: |
-          if [ -z ${{ steps.set-comment-body.outputs.COMMENT_BODY }} ]; then
+          if [ -z "${{ steps.set-comment-body.outputs.COMMENT_BODY }}" ]; then
             echo "No commits to document."
             exit 0
           fi


### PR DESCRIPTION
This pull request fixes a conditional statement in the DocumentMergedCommits.yaml workflow. The previous code had an issue with multiline comments. The fix ensures that the workflow won't create warnings.