### PR TITLE
Fix cherry-pick issues

### DIFF
--- a/.github/workflows/UpdateTestBranch.yaml
+++ b/.github/workflows/UpdateTestBranch.yaml
@@ -156,11 +156,10 @@ jobs:
             echo "::debug::Full message: $msg"
             last_line=$(echo "$msg" | tail -n 1)
             echo "::debug::Last line: $last_line"
-            if [[ $last_line != "CP:"* ]]; then
+            commit=$(echo "$body" | grep -oP '(?<=\(cherry picked from commit )\S*(?=\))')
+            if [[ -z "$commit" ]]; then
               continue
             fi
-
-            commit=${last_line#CP:}
             echo "::debug::Commit: $commit"
             if [[ $(git rev-parse --verify "$commit" 2>/dev/null) ]]; then
               commit=${commit:0:7}
@@ -291,16 +290,11 @@ jobs:
           success=true
 
           for commit in "${feature_commits[@]}"; do
-            message=$(git log --format=%s -n 1 $commit)
-            message=$message'
-
-          CP:'$commit
-            git cherry-pick --allow-empty $commit 1>/dev/null || true
+            git cherry-pick --allow-empty -x $commit 1>/dev/null || true
             if [ -n "$(git status --porcelain | grep '^U')" ]; then
               $success=false
               break
             fi
-            git commit --amend -m "$message"
             successful_commits+=($commit)
           done
 
@@ -451,7 +445,7 @@ jobs:
           git fetch origin ${{ env.FEATURE_TEST_BRANCH }}
           git checkout ${{ env.FEATURE_TEST_BRANCH }}
           git pull origin ${{ env.FEATURE_TEST_BRANCH }}
-          git cherry-pick '"$failed_commit"'
+          git cherry-pick -x '"$failed_commit"'
           ```
           2) Resolve the merge conflicts and push the changes.
           3) Re-run the workflow by commenting `!update-test-branch` in ${{ github.event.issue.pull_request.html_url }} again.'

--- a/.github/workflows/UpdateTestBranch.yaml
+++ b/.github/workflows/UpdateTestBranch.yaml
@@ -294,7 +294,7 @@ jobs:
             message=$message'
 
           CP:'$commit
-            git cherry-pick $commit 1>/dev/null || true
+            git cherry-pick --allow-empty $commit 1>/dev/null || true
             if [ -n "$(git status --porcelain | grep '^U')" ]; then
               echo '::error::Cherry-pick failed. Please see ${{ github.event.issue.pull_request.html_url }} for more details.'
               exit 1

--- a/.github/workflows/UpdateTestBranch.yaml
+++ b/.github/workflows/UpdateTestBranch.yaml
@@ -288,6 +288,7 @@ jobs:
           echo "Cherry-picking the following commits:"
           echo "${feature_commits[*]}"
           successful_commits=()
+          success=true
 
           for commit in "${feature_commits[@]}"; do
             message=$(git log --format=%s -n 1 $commit)
@@ -296,19 +297,25 @@ jobs:
           CP:'$commit
             git cherry-pick --allow-empty $commit 1>/dev/null || true
             if [ -n "$(git status --porcelain | grep '^U')" ]; then
-              echo '::error::Cherry-pick failed. Please see ${{ github.event.issue.pull_request.html_url }} for more details.'
-              exit 1
+              $success=false
+              break
             fi
             git commit --amend -m "$message"
             successful_commits+=($commit)
           done
-          echo "Cherry-pick successful."
 
           {
             echo "PICKED_COMMITS<<EOF"
             echo "${successful_commits[*]}"
             echo "EOF"
           } >> $GITHUB_ENV
+
+          if [ $success == false ]; then
+            echo '::error::Cherry-pick failed. Please see ${{ github.event.issue.pull_request.html_url }} for more details.'
+            exit 1
+          else
+            echo "Cherry-pick successful."
+          fi
 
       - name: "On success: Commit & push cherry-picked changes"
         if: ${{ env.SKIP_ALL == 'false' && steps.cherry_pick.outcome == 'success' }}


### PR DESCRIPTION
This pull request fixes issues related to cherry-picking commits:
- Empty commits no longer cause a false negative on cherry-picking
- Successful commits now get written to the environment even in the case of a merge conflict
- The cherry-pick commit message is now generated using the '-x' flag, ensuring manual cherry-picks contain the original commit in the message