### PR TITLE
Fix delete job to handle missing branch

### DIFF
--- a/.github/workflows/DocumentMergedCommits.yaml
+++ b/.github/workflows/DocumentMergedCommits.yaml
@@ -212,7 +212,7 @@ jobs:
       - name: Delete head branch
         run: |
             branch=${{ github.head_ref }}
-            if git ls-remote --heads origin $branch >/dev/null 2>&1; then
+            if [ -n "$(git ls-remote --heads origin $branch)" ]; then
               git push origin --delete $branch
             else
               echo "Unable to locate branch $branch - It most likely has already been deleted."

--- a/.github/workflows/UpdateTestBranch.yaml
+++ b/.github/workflows/UpdateTestBranch.yaml
@@ -335,6 +335,13 @@ jobs:
             echo "Cherry-pick successful."
           fi
 
+      - name: Add reaction based on cherry-pick outcome
+        if: ${{ env.SKIP_ALL == 'false' }}
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          reactions: ${{ steps.cherry_pick.outcome == 'success' && '+1' || '-1' }}
+
       - name: "On success: Commit & push cherry-picked changes"
         if: ${{ env.SKIP_ALL == 'false' && steps.cherry_pick.outcome == 'success' }}
         run: |


### PR DESCRIPTION
This pull request updates the delete job to avoid an error if the branch is missing. Previously, the job would fail if the branch was not found. With this change, the job will check if the branch exists before attempting to delete it. If the branch is not found, a message will be displayed indicating that the branch has already been deleted. This ensures that the delete job can handle different scenarios and prevents unnecessary errors.