### PR TITLE
Update if conditions in UpdateTestBranch.yaml workflow

### DIFF
--- a/.github/workflows/UpdateTestBranch.yaml
+++ b/.github/workflows/UpdateTestBranch.yaml
@@ -429,7 +429,7 @@ jobs:
         run: |
           feature_test_branch=${{ env.FEATURE_TEST_BRANCH }}
           test_branch=${{ env.TEST_BRANCH }}
-          if [ -n "$(gh pr list --base $test_branch --head $feature_test_branch --state open | wc -l)" ]; then
+          if [ $(gh pr list --base $test_branch --head $feature_test_branch --state open | wc -l) -gt 0 ]; then
             echo "PR already exists."
             echo "NO_CHANGES=false" >> $GITHUB_ENV
             echo "PR_EXISTS=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request updates the if conditions in the UpdateTestBranch.yaml workflow. The previous condition was checking if the output of `gh pr list` was not empty, but it should be checking if the count of open pull requests is greater than 0. This change ensures that the condition is correctly evaluated.