### PR TITLE
Update DocumentMergedCommits.yaml workflow to correctly handle multiline comment bodies

### DIFF
--- a/.github/workflows/DocumentMergedCommits.yaml
+++ b/.github/workflows/DocumentMergedCommits.yaml
@@ -171,7 +171,7 @@ jobs:
         run: |
           picked_commits=(${{ env.PICKED_COMMITS }})
           if [ -n "$picked_commits" ]; then
-            body='${{ github.event.pull_request.html_url }} merged the following commits from \`${{ env.FEATURE_BRANCH }}\` into \`${{ github.head_ref }}\`:
+            body='${{ github.event.pull_request.html_url }} merged the following commits from '${{ env.FEATURE_BRANCH }}' into '${{ github.head_ref }}':
 
           '
             for commit in "${picked_commits[@]}"; do
@@ -179,7 +179,7 @@ jobs:
           "
             done
             body="$body"'
-          This list contains all commits that were successfully squash merged into \`${{ github.base_ref }}\` by ${{ github.event.pull_request.html_url }}. To ensure the update workflow is working as expected, please do not remove or add any commits to this comment.'
+          This list contains all commits that were successfully squash merged into '${{ github.base_ref }}' by ${{ github.event.pull_request.html_url }}. To ensure the update workflow is working as expected, please do not remove or add any commits to this comment.'
             echo -e "$body"
             {
               echo "COMMENT_BODY<<EOF"
@@ -193,16 +193,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          read -r -d '' comment_body << EOM
-          ${{ steps.set-comment-body.outputs.COMMENT_BODY }}
-          EOM
-          if [ -z "$comment_body" ]; then
+          if [ -z '${{ steps.set-comment-body.outputs.COMMENT_BODY }}' ]; then
             echo "No commits to document."
             exit 0
           fi
-          echo $comment_body
+          echo ${{ steps.set-comment-body.outputs.COMMENT_BODY }}
           gh pr comment ${{ env.FEATURE_PR_NUMBER }} --body '${{ env.COMMIT_COMMENT_TAG }}
-          '"$comment_body"
+          ${{ steps.set-comment-body.outputs.COMMENT_BODY }}'
 
   delete-head:
     name: Delete head branch


### PR DESCRIPTION
This pull request updates the `DocumentMergedCommits.yaml` workflow to correctly handle multiline comment bodies. The previous implementation was not handling multiline comment bodies properly, causing issues with the comment formatting. This update ensures that the comment bodies are handled correctly, allowing for proper formatting and readability.